### PR TITLE
mac example instructions

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -2,12 +2,13 @@ Example jupyter kernel
 ----------------------
 
 To install locally, copy `kernel.json` from this directory to
-`~/.local/share/jupyter/kernels/<name>/kernel.json`. The directory
+`~/.local/share/jupyter/kernels/<name>/kernel.json` (linux) or
+`~/Library/Jupyter/kernels/<name>/kernel.json` (mac). The directory
 name can be anything. The `example_kernel` executable build by `dub`
 will have to be in the `PATH`, otherwise edit `kernel.json` to point
 to the path where it is located.
 
-To install globally, use `/usr/share/jupyter/kernels` instead of
+To install globally, use `/usr/share/jupyter/kernels` (linux and mac) instead of
 `~/.local/share/jupyter/kernels`.
 
 And that's it. When you run `jupyter notebook` you'll see `jupyter-wire-example`


### PR DESCRIPTION
The `kernel.json` file is in a different place for mac.