### PR TITLE
put in default value for username

### DIFF
--- a/source/jupyter/wire/message.d
+++ b/source/jupyter/wire/message.d
@@ -87,6 +87,9 @@ struct Message {
 
         header.date = (cast(DateTime)Clock.currTime).toISOExtString;
         header.msgID = randomUUID.toString;
+	// set username to non-null string otherwise the you can get
+	// failures on jupyterlab
+	header.userName = "username";
     }
 
     private string signature(in string key) @safe {


### PR DESCRIPTION
Fix symmetryinvestments/jupyter-wire#27.  This puts in a default value
for username so that the msg header does not put in an empty value
that will convert to None.  Because the there is no default value,
username is undefined which causes failures.