### PR TITLE
set null username and session fields to empty strings

### DIFF
--- a/source/jupyter/wire/kernel.d
+++ b/source/jupyter/wire/kernel.d
@@ -134,6 +134,17 @@ struct Kernel(Backend) if(isBackend!Backend) {
             log("Received message from the front-end.");
         }
 
+        // Set username and session to empty string
+        // Keeping the the fields as null will forward
+        // None to the FE
+        if (requestMessage.get.header.userName is null) {
+            requestMessage.get.header.userName = "";
+        }
+
+        if (requestMessage.get.header.session is null) {
+            requestMessage.get.header.session = "";
+        }
+
         handleRequestMessage(requestMessage.get);
     }
 

--- a/source/jupyter/wire/message.d
+++ b/source/jupyter/wire/message.d
@@ -87,6 +87,11 @@ struct Message {
 
         header.date = (cast(DateTime)Clock.currTime).toISOExtString;
         header.msgID = randomUUID.toString;
+        // set username and session to non-null string
+        // otherwise the you can get failures on jupyterlab
+        // when zmq returns None other than a string
+        header.userName = "";
+        header.session = "";
     }
 
     private string signature(in string key) @safe {


### PR DESCRIPTION
This fixes symmetryinvestments/jupyter-wire#27 in which jupyter-wire
kernels will fail with jupyterlab.  The issue is that the headers will
have nulls rather than empty strings which results in the message sent
to the frontend being None which will cause the frontend to not work.