### PR TITLE
fix null session

### DIFF
--- a/source/jupyter/wire/message.d
+++ b/source/jupyter/wire/message.d
@@ -47,6 +47,12 @@ struct Message {
         if (parentHeader.userName is null)
             parentHeader.userName = "";
 
+        if (header.session is null)
+            header.session = "";
+
+        if (parentHeader.session is null)
+            parentHeader.session = "";
+
         metadata = parseJSON(strings[delimiterIndex + 4]);
         content = parseJSON(strings[delimiterIndex + 5]);
         extraRawData = strings[delimiterIndex + 6 .. $].dup;
@@ -126,7 +132,7 @@ struct MessageHeader {
     @serdeKeys("msg_id")   string msgID;
     @serdeKeys("msg_type") string msgType;
     @serdeKeys("username") string userName = "";
-                     string session;
+                     string session = "";
                      string date;
     @serdeKeys("version")  string protocolVersion;
 

--- a/tests/ut/message.d
+++ b/tests/ut/message.d
@@ -15,6 +15,18 @@ unittest {
   message.header.userName.shouldNotBeNull;
 }
 
+@("messageheader.non-null.session")
+unittest {
+  MessageHeader.empty.session.shouldNotBeNull;
+}
+
+@("message.non-null.session")
+unittest {
+  auto message = Message(MessageHeader.empty, "dummy-type");
+  message.parentHeader.session.shouldNotBeNull;
+  message.header.session.shouldNotBeNull;
+}
+
 @("message.copy-username")
 unittest {
   auto message = Message(MessageHeader("id", "type", "username"), "dummy-type");
@@ -30,9 +42,11 @@ unittest {
   message.header.userName.shouldEqual("username");
 }
 
-@("message.receive.non-null.username")
+@("message.receive.non-null.username-and-session")
 unittest {
   auto message = Message(["<IDS|MSG>", "f3ceaa87a37567bf6e6431c75460596f2e8bd609960ccffc1224cc1105debe09", "{\"msg_id\":\"7e65fba6-d785-4a0c-95ee-6be99ba8ed17\",\"msg_type\":\"dummy-type\",\"session\":null,\"date\":\"2020-11-15T15:06:37\",\"version\":null}", "{\"msg_id\":\"id\",\"msg_type\":\"type\",\"session\":null,\"date\":null,\"version\":null}", "{}", "{}"]);
   message.parentHeader.userName.shouldNotBeNull;
   message.header.userName.shouldNotBeNull;
+  message.parentHeader.session.shouldNotBeNull;
+  message.header.session.shouldNotBeNull;
 }


### PR DESCRIPTION
Insure that frontends receive empty strings for session rather than
null strings.  Null strings will get converted to None on the frontend
and break jupyterlab.